### PR TITLE
fix(jest-next.js): rectify broken jest `moduleNameMapper` configuration

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,10 +2,6 @@ const { pathsToModuleNameMapper } = require('ts-jest');
 const { compilerOptions } = require('./tsconfig.json');
 const nextJest = require('next/jest');
 
-const paths = pathsToModuleNameMapper(compilerOptions.paths, {
-  prefix: '<rootDir>/',
-});
-
 /** @type {import('ts-jest').InitialOptionsTsJest} */
 const customJestConfig = {
   collectCoverage: true,
@@ -26,9 +22,6 @@ const customJestConfig = {
     '!**/Header.tsx',
   ],
   moduleDirectories: ['node_modules', '<rootDir>/'],
-  moduleNameMapper: {
-    ...paths,
-  },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'jest-environment-jsdom',
 };
@@ -38,7 +31,19 @@ const createJestConfig = nextJest({
 })(customJestConfig);
 
 module.exports = async () => {
+  // Create Next.js jest configuration presets
   const jestConfig = await createJestConfig();
+
+  // Custom `moduleNameMapper` configuration
+  const paths = pathsToModuleNameMapper(compilerOptions.paths, {
+    prefix: '<rootDir>/',
+  });
+  const moduleNameMapper = {
+    ...jestConfig.moduleNameMapper,
+    ...paths,
+  };
+
+  // Custom `transformIgnorePatterns` configuration
   const transformIgnorePatterns = [
     // Transform ESM-only modules in `node_modules`.
     '/node_modules/(?!next-mdx-remote|@mdx-js|@react-hook)',
@@ -46,5 +51,6 @@ module.exports = async () => {
       pattern => pattern !== '/node_modules/'
     ),
   ];
-  return { ...jestConfig, transformIgnorePatterns };
+
+  return { ...jestConfig, moduleNameMapper, transformIgnorePatterns };
 };


### PR DESCRIPTION
Rectify Jest configuration for renovate-bot #814 pull request.

close #815
issue vercel/next.js#35634
issue vercel/next.js#36312
issue vercel/next.js#36682

<!--
  Thank you for sending the PR!

  If you changed any code,
  please provide us with clear instructions on how you verified your changes work.
  Bonus points for screenshots!

  Happy contributing!
-->

# Pull Request

<!--
  Make sure the `Allow edits and access to secrets by maintainers` checkbox
  is checked on this pull request.
-->

## This PR Contains

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

## Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

## Breaking Changes

<!--
  If this PR introduces a breaking change,
  please describe the impact and a migration path for existing applications.
-->

## Test-Case

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

## Additional Info

<!--
  Do you have any suggestions about this PR template?
  Edit it here: https://github.com/sabertazimi/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md
-->

<!--
  Please do not force push to your PR's branch after you have created your PR,
  as doing so forces us to review the whole PR again.
  This makes it harder for us to review your work because we don't know what has changed.
  PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch.
-->
